### PR TITLE
CMake: Find module for Sparkle and its exported target instead of hardcoding values here

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,9 @@ add_library(
   ${SOURCE_FILES}
 )
 
-SET(CMAKE_CXX_FLAGS "-F${CMAKE_CURRENT_SOURCE_DIR}/../cocoapods/Pods/Sparkle")
+find_package(Sparkle)
 
 target_link_libraries( cocoa-qt-glue
-  "-framework Sparkle"
   "-framework AppKit"
+  Sparkle::Sparkle
 )


### PR DESCRIPTION
This is a bit better for style and is needed (a bit later) to make a created app bundle executable. Otherwise, it won't find the sparkle and crash.