### PR TITLE
Upgrade to Sparkle 2 API

### DIFF
--- a/AutoUpdater.h
+++ b/AutoUpdater.h
@@ -19,7 +19,6 @@ public:
     virtual void setAutomaticallyDownloadsUpdates(bool on) = 0;
     virtual bool automaticallyDownloadsUpdates() = 0;
 
-    virtual bool justUpdated() = 0;
 };
 
 #endif

--- a/Sparkle.framework
+++ b/Sparkle.framework
@@ -1,1 +1,0 @@
-/Library/Frameworks/Sparkle.framework

--- a/SparkleAutoUpdater.h
+++ b/SparkleAutoUpdater.h
@@ -13,7 +13,7 @@
 class SparkleAutoUpdater : public AutoUpdater
 {
 	public:
-		SparkleAutoUpdater(const QString& url);
+		SparkleAutoUpdater();
 		~SparkleAutoUpdater();
 
 		void checkForUpdates() override;
@@ -24,13 +24,9 @@ class SparkleAutoUpdater : public AutoUpdater
 		void setAutomaticallyDownloadsUpdates(bool on) override;
 		bool automaticallyDownloadsUpdates() override;
 
-		bool justUpdated() override;
-		void setRelaunchFlag();
-
 	private:
 		class Private;
 		Private* d;
-		bool relaunchedFromUpdate;
 };
 
 #endif


### PR DESCRIPTION
Major changes in the API are outlined here: https://sparkle-project.org/documentation/upgrading/
Support for notification on launch after update was removed from Sparkle 2, so taking it out here.

Feeds are now 100% set in Info.plist (previously they had been passed in to SparkleAutoUpdater as well as set in the plist). 
Setting them manually via -setFeedURL: has been deprecated, so removed that, and added the recommended action to remove them from the host bundle on init, if they exist in earlier installs.
